### PR TITLE
avoid from bundling npms of lambda functions

### DIFF
--- a/bin/meigaza.ts
+++ b/bin/meigaza.ts
@@ -2,12 +2,13 @@
 import "source-map-support/register";
 import * as cdk from "@aws-cdk/core";
 import { MeigazaStack } from "../lib/meigaza-stack";
-import { setUpLambdaLayer } from "../lib/setup-lambda-layer";
+import { setUpLambdaLayer, cleanParcelCacheDir } from "../lib/setup-lambda-layer";
 
 if (!process.env.SLACK_INCOMING_WEBHOOK_URL) {
   throw new Error("not set environment. execute `. .env.sh` before cdk command.");
 }
 
+cleanParcelCacheDir();
 setUpLambdaLayer();
 
 const app = new cdk.App();

--- a/lib/lambdas/package.json
+++ b/lib/lambdas/package.json
@@ -2,7 +2,6 @@
   "name": "meigaza-lambdas",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "scripts": {
     "test": "jest"
   },

--- a/lib/lambdas/package.json
+++ b/lib/lambdas/package.json
@@ -15,19 +15,6 @@
     "date-fns": "^2.15.0",
     "puppeteer-core": "^5.2.1"
   },
-  "targets": {
-    "cdk-lambda": {
-      "context": "node",
-      "includeNodeModules": {
-        "aws-sdk": false
-      },
-      "sourceMap": false,
-      "minify": false,
-      "engines": {
-        "node": ">= 12"
-      }
-    }
-  },
   "devDependencies": {
     "@types/axios": "^0.14.0",
     "@types/jest": "^26.0.10",

--- a/lib/meigaza-stack.ts
+++ b/lib/meigaza-stack.ts
@@ -25,6 +25,7 @@ export class MeigazaStack extends Stack {
       timeout: Duration.minutes(3),
       sourceMaps: true,
       externalModules: ["aws-sdk", ...npms],
+      cacheDir: ".cache",
     };
 
     const meigazaFunction = new NodejsFunction(this, "meigaza", {

--- a/lib/meigaza-stack.ts
+++ b/lib/meigaza-stack.ts
@@ -5,7 +5,7 @@ import { Rule, Schedule } from "@aws-cdk/aws-events";
 import { LambdaFunction } from "@aws-cdk/aws-events-targets";
 import { RetentionDays } from "@aws-cdk/aws-logs";
 import * as path from "path";
-import { LAMBDA_LAYER_DIR } from "./setup-lambda-layer";
+import { LAMBDA_LAYER_DIR, lambdaDependencies } from "./setup-lambda-layer";
 
 export class MeigazaStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -16,12 +16,15 @@ export class MeigazaStack extends Stack {
       compatibleRuntimes: [Runtime.NODEJS_12_X],
     });
 
+    const npms = lambdaDependencies();
     const lambdaOptions = {
       runtime: Runtime.NODEJS_12_X,
       memorySize: 1600,
       logRetention: RetentionDays.SIX_MONTHS,
       layers: [layer],
       timeout: Duration.minutes(3),
+      sourceMaps: true,
+      externalModules: ["aws-sdk", ...npms],
     };
 
     const meigazaFunction = new NodejsFunction(this, "meigaza", {

--- a/lib/meigaza-stack.ts
+++ b/lib/meigaza-stack.ts
@@ -5,7 +5,7 @@ import { Rule, Schedule } from "@aws-cdk/aws-events";
 import { LambdaFunction } from "@aws-cdk/aws-events-targets";
 import { RetentionDays } from "@aws-cdk/aws-logs";
 import * as path from "path";
-import { LAMBDA_LAYER_DIR, lambdaDependencies } from "./setup-lambda-layer";
+import { LAMBDA_LAYER_DIR, lambdaDependencies, PARCEL_CACHE_BASE_DIR } from "./setup-lambda-layer";
 
 export class MeigazaStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -25,7 +25,6 @@ export class MeigazaStack extends Stack {
       timeout: Duration.minutes(3),
       sourceMaps: true,
       externalModules: ["aws-sdk", ...npms],
-      cacheDir: ".cache",
     };
 
     const meigazaFunction = new NodejsFunction(this, "meigaza", {
@@ -34,6 +33,7 @@ export class MeigazaStack extends Stack {
       environment: {
         SLACK_INCOMING_WEBHOOK_URL: process.env.SLACK_INCOMING_WEBHOOK_URL || "",
       },
+      cacheDir: `./${PARCEL_CACHE_BASE_DIR}/meigaza`,
       ...lambdaOptions,
     });
 
@@ -54,6 +54,7 @@ export class MeigazaStack extends Stack {
         IFTTT_WEBHOOK_URL: process.env.IFTTT_WEBHOOK_URL || "",
         SLACK_INCOMING_WEBHOOK_URL: process.env.SLACK_INCOMING_WEBHOOK_URL || "",
       },
+      cacheDir: `./${PARCEL_CACHE_BASE_DIR}/mvtk`,
       ...lambdaOptions,
     });
 

--- a/lib/setup-lambda-layer.ts
+++ b/lib/setup-lambda-layer.ts
@@ -2,10 +2,13 @@ import * as childProcess from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as crypt from "crypto";
+import * as rimraf from "rimraf";
 
 export const LAMBDA_LAYER_DIR = `${process.cwd()}/layer`;
 const LAMBDA_LAYER_RUNTIME_DIR = "nodejs";
 const LAMBDA_DIR = path.join(__dirname, "lambdas");
+
+export const PARCEL_CACHE_BASE_DIR = ".parcel-cache";
 
 const PACKAGE_JSON = "package.json";
 const PACKAGE_LOCK_JSON = "package-lock.json";
@@ -51,4 +54,8 @@ export function lambdaDependencies(): string[] {
   const packageJson = JSON.parse(packageJsonString);
   const dependencies = packageJson["dependencies"];
   return Object.keys(dependencies);
+}
+
+export function cleanParcelCacheDir(): void {
+  rimraf.sync(PARCEL_CACHE_BASE_DIR);
 }

--- a/lib/setup-lambda-layer.ts
+++ b/lib/setup-lambda-layer.ts
@@ -10,7 +10,7 @@ const LAMBDA_DIR = path.join(__dirname, "lambdas");
 const PACKAGE_JSON = "package.json";
 const PACKAGE_LOCK_JSON = "package-lock.json";
 
-export function setUpLambdaLayer() {
+export function setUpLambdaLayer(): void {
   const targetDir = path.join(LAMBDA_LAYER_DIR, LAMBDA_LAYER_RUNTIME_DIR);
   fs.mkdirSync(targetDir, { recursive: true });
 
@@ -43,4 +43,12 @@ function md5hash(filePath: string) {
   const hash = crypt.createHash("md5");
   hash.update(buffer);
   return hash.digest("base64");
+}
+
+export function lambdaDependencies(): string[] {
+  const file = path.join(LAMBDA_DIR, PACKAGE_JSON);
+  const packageJsonString = fs.readFileSync(file, "utf-8");
+  const packageJson = JSON.parse(packageJsonString);
+  const dependencies = packageJson["dependencies"];
+  return Object.keys(dependencies);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4061,6 +4061,16 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
+    "@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
@@ -4111,6 +4121,12 @@
       "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
       "dev": true
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
@@ -4140,6 +4156,16 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
       "dev": true
+    },
+    "@types/rimraf": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@aws-cdk/assert": "^1.60.0",
     "@types/jest": "^26.0.10",
     "@types/node": "^14.6.0",
+    "@types/rimraf": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^3.10.0",
     "@typescript-eslint/parser": "^3.10.0",
     "aws-cdk": "^1.60.0",
@@ -55,6 +56,7 @@
     "lint-staged": "^10.2.11",
     "parcel": "^2.0.0-beta.1",
     "prettier": "^2.1.0",
+    "rimraf": "^3.0.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.2"


### PR DESCRIPTION
```🚨 Build failed.
Error: Cannot read property 'hashReferences' of undefined
TypeError: Cannot read property 'hashReferences' of undefined
    at getBundlesIncludedInHash (/home/runner/work/meigaza/meigaza/node_modules/@parcel/core/lib/PackagerRunner.js:491:47)
    at getBundlesIncludedInHash (/home/runner/work/meigaza/meigaza/node_modules/@parcel/core/lib/PackagerRunner.js:495:7)
    at getBundlesIncludedInHash (/home/runner/work/meigaza/meigaza/node_modules/@parcel/core/lib/PackagerRunner.js:495:7)
    at assignComplexNameHashes (/home/runner/work/meigaza/meigaza/node_modules/@parcel/core/lib/PackagerRunner.js:483:31)
    at PackagerRunner.writeBundles (/home/runner/work/meigaza/meigaza/node_modules/@parcel/core/lib/PackagerRunner.js:110:5)
    at process._tickCallback (internal/process/next_tick.js:68:7)
Failed to bundle asset MeigazaStack/mvtk/Code/Stage: Error: bash exited with status 1
Subprocess exited with error 1
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! meigaza@1.0.0 cdk: `cdk "diff"`
```